### PR TITLE
[Platform-95] Add retry functionality for snowplow failed events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Install
 
 You have to send events from a Java/kotlin Application to Snowplow. Maybe you have to do this from several services.
 In order to not implement and configure the [Snowplow Java Tracker](https://github.com/snowplow/snowplow/wiki/Java-Tracker) several times you can use this wrapper instead.
+This also provides retry mechanism for failed snowplow events. By default it retries for 5 times before calling the failure callback. 
 
 ### How to use
 
@@ -78,7 +79,6 @@ class SnowplowMapper(private val snowplowSchemaProvider: SnowplowSchemaProvider)
             mapOf("my_app_context_name" to myEvent.attributes.appName)
         ))
 }
-
 ```
 
 ### _snowplowDispatcher_ doc

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ class SnowplowEventDispatcher(private val snowplowMapper: SnowplowMapper) {
         appId = "my-app-id",
         nameSpace = "app-namespace",
         collectorUrl = "http://localhost:1080",
+        retryCount = 5, /* Number of retries on failure, by default its 5 */
         onFailure = { successCount, failedEvents -> /* onFailure code logic */} // this is optional
     )
 
@@ -49,7 +50,7 @@ class SnowplowEventDispatcher(private val snowplowMapper: SnowplowMapper) {
 }
 
 /**
- *  Snowplow mapper example to include the usedId on subject
+ *  Snowplow mapper example to include the userId on subject
  */
 class SnowplowMapper(private val snowplowSchemaProvider: SnowplowSchemaProvider) {
 
@@ -89,6 +90,7 @@ class SnowplowMapper(private val snowplowSchemaProvider: SnowplowSchemaProvider)
  * @param collectorUrl snowplow URL
  * @param bufferSize Specifies how many events go into a POST, default 1
  * @param threadCount The number of Threads that can be used to send events, default 50
+ * @param retryCount The number of retry attempts before calling [FailureCallback], default 5
  * @param base64 enable base 64 encoding, default true
  * @param onSuccess [(successCount: Int) -> Unit] called to each success request, default null
  * @param onFailure [(successCount: Int, failedEvents: List<Event>) -> Unit] called to each failed request, default null
@@ -99,6 +101,7 @@ fun snowplowDispatcher(
     collectorUrl: String,
     bufferSize: Int = 1,
     threadCount: Int = 50,
+    retryCount: Int = 5,
     base64: Boolean = true,
     onSuccess: SuccessCallback? = null,
     onFailure: FailureCallback? = null

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.21</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <snowplow-java-tracker.version>0.10.1</snowplow-java-tracker.version>
-        <ktor-client-apache.version>1.2.4</ktor-client-apache.version>
+        <ktor-client-apache.version>1.5.0</ktor-client-apache.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <junit-jupiter-api.version>5.6.2</junit-jupiter-api.version>
+        <junit-jupiter-api.version>5.7.0</junit-jupiter-api.version>
+        <io.mockk.version>1.10.2</io.mockk.version>
+        <mockserver-netty.version>5.11.2</mockserver-netty.version>
     </properties>
 
     <dependencies>
@@ -74,21 +76,14 @@
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
-            <version>1.9.3.kotlin12</version>
+            <version>${io.mockk.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.10.8</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>3.10.8</version>
+            <version>${mockserver-netty.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/kotlin/snowplowjavatrackertracker/RetryFailedEvents.kt
+++ b/src/main/kotlin/snowplowjavatrackertracker/RetryFailedEvents.kt
@@ -1,0 +1,54 @@
+package snowplowjavatrackertracker
+
+import com.snowplowanalytics.snowplow.tracker.events.Event
+import kotlin.math.pow
+import kotlin.random.Random
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+internal class RetryFailedEvents(
+    private val snowplowAppProperties: SnowplowAppProperties,
+    private val retryCount: Int,
+    private val successCallback: SuccessCallback,
+    private val finalFailureCallback: FailureCallback
+) {
+    private var retryAttemptCounter = retryCount
+
+    suspend fun sendEvent(event: Event) =
+        with(snowplowAppProperties) {
+            SnowplowDispatcher(tracker(nameSpace, appId, true,
+                emitter(collectorUrl,
+                    EMITTER_SIZE,
+                    THREAD_COUNT,
+                    { retrySuccess(it) },
+                    { successCount, failedEvents ->
+                        runBlocking { retryFailure(successCount, failedEvents) }
+                    })))
+                .send(event)
+        }
+
+    private fun retrySuccess(successCount: Int) = successCallback(successCount)
+
+    private suspend fun retryFailure(successCount: Int, failedEvents: List<Event>) {
+        when {
+            retryAttemptCounter > 1 -> {
+                delay(retryAttemptCounter.delay().toLong())
+                failedEvents.forEach { sendEvent(it) }
+                retryAttemptCounter--
+            }
+            else -> {
+                finalFailureCallback(successCount, failedEvents)
+            }
+        }
+    }
+
+    private fun Int.delay() = INITIAL_DELAY * EXPONENTIAL_BASE.pow(retryCount - this + 1) + RANDOM_FACTOR
+
+    companion object {
+        private const val EMITTER_SIZE = 1
+        private const val THREAD_COUNT = 50
+        private const val INITIAL_DELAY = 300
+        private const val EXPONENTIAL_BASE = 2.0
+        private val RANDOM_FACTOR = Random.nextInt(100, 500)
+    }
+}

--- a/src/main/kotlin/snowplowjavatrackertracker/SnowplowAppProperties.kt
+++ b/src/main/kotlin/snowplowjavatrackertracker/SnowplowAppProperties.kt
@@ -1,0 +1,7 @@
+package snowplowjavatrackertracker
+
+data class SnowplowAppProperties(
+    val appId: String,
+    val collectorUrl: String,
+    val nameSpace: String
+)

--- a/src/main/kotlin/snowplowjavatrackertracker/SnowplowAppProperties.kt
+++ b/src/main/kotlin/snowplowjavatrackertracker/SnowplowAppProperties.kt
@@ -1,7 +1,13 @@
 package snowplowjavatrackertracker
 
+/**
+ * App properties to emit Snowplow events
+ */
 data class SnowplowAppProperties(
     val appId: String,
     val collectorUrl: String,
-    val nameSpace: String
+    val nameSpace: String,
+    val isBase64Encoded: Boolean,
+    val emitterBufferSize: Int,
+    val emitterThreadCount: Int
 )

--- a/src/main/kotlin/snowplowjavatrackertracker/SnowplowDispatcher.kt
+++ b/src/main/kotlin/snowplowjavatrackertracker/SnowplowDispatcher.kt
@@ -5,6 +5,6 @@ import com.snowplowanalytics.snowplow.tracker.events.Event
 
 class SnowplowDispatcher(private val tracker: Tracker) {
     fun send(event: Event?) {
-        event?.let { tracker.track(event) }
+            event?.let { tracker.track(event) }
     }
 }

--- a/src/test/kotlin/snowplowjavatrackertracker/Fixtures.kt
+++ b/src/test/kotlin/snowplowjavatrackertracker/Fixtures.kt
@@ -1,0 +1,22 @@
+package snowplowjavatrackertracker
+
+import com.snowplowanalytics.snowplow.tracker.Subject
+import com.snowplowanalytics.snowplow.tracker.events.Unstructured
+import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload
+
+object Fixtures {
+
+    fun event(
+        eventData: SelfDescribingJson = eventData(),
+        userId: String = "my-id-1",
+    ): Unstructured = Unstructured.builder()
+        .eventData(eventData)
+        .subject(Subject.SubjectBuilder().userId(userId).build())
+        .build()
+
+    private fun eventData(
+        schema: String = "schema",
+        data: Map<String, String> = mapOf("key" to "value"),
+    ): SelfDescribingJson = SelfDescribingJson(schema, TrackerPayload().apply { addMap(data) })
+}

--- a/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherIntegrationTest.kt
+++ b/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherIntegrationTest.kt
@@ -1,9 +1,6 @@
 package snowplowjavatrackertracker
 
-import com.snowplowanalytics.snowplow.tracker.Subject
-import com.snowplowanalytics.snowplow.tracker.events.Unstructured
-import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson
-import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload
+import com.snowplowanalytics.snowplow.tracker.events.Event
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterAll
@@ -19,6 +16,10 @@ class SnowplowDispatcherIntegrationTest {
 
     private lateinit var server: ClientAndServer
 
+    private val successCallback = mockk<(Int) -> Unit>(relaxed = true)
+
+    private val failureCallback = mockk<(Int, List<Event>) -> Unit>(relaxed = true)
+
     @BeforeAll
     fun startServer() {
         server = ClientAndServer.startClientAndServer(1080)
@@ -32,9 +33,6 @@ class SnowplowDispatcherIntegrationTest {
 
     @Test
     fun `should call mapper and success callback when sending valid event`() {
-        val json = SelfDescribingJson("schema", TrackerPayload().apply { addMap(mapOf("key" to "value")) })
-        val successCallback = mockk<(Int) -> Unit>(relaxed = true)
-
         val dispatcher = snowplowDispatcher(
             appId = "my-app-id",
             nameSpace = "app-namespace",
@@ -42,29 +40,15 @@ class SnowplowDispatcherIntegrationTest {
             onSuccess = successCallback
         )
 
-        dispatcher.send(
-            Unstructured.builder()
-                .eventData(json)
-                .subject(Subject.SubjectBuilder().userId("my-id-1").build())
-                .build()
-        )
-        dispatcher.send(
-            Unstructured.builder()
-                .eventData(json)
-                .subject(Subject.SubjectBuilder().userId("my-id-2").build())
-                .build()
-        )
+        dispatcher.send(Fixtures.event(userId = "my-id-1"))
+        dispatcher.send(Fixtures.event(userId = "my-id-2"))
 
         verify(timeout = 500, exactly = 2) { successCallback(1) }
     }
 
     @Test
     fun `should not throw an exception`() {
-        val json = SelfDescribingJson("schema", TrackerPayload().apply { addMap(mapOf("key" to "value")) })
-        val event = Unstructured.builder()
-            .eventData(json)
-            .subject(Subject.SubjectBuilder().userId("my-id").build())
-            .build()
+        val event = Fixtures.event()
 
         val dispatcher = snowplowDispatcher(
             "my-name",
@@ -73,5 +57,39 @@ class SnowplowDispatcherIntegrationTest {
             1, 1
         )
         dispatcher.send(event)
+    }
+
+    @Test
+    fun `should call success callback after successfully re-sending failed event`() {
+        val event1: Event = Fixtures.event(userId = "user-1")
+
+        retryFailedEvent(
+            failedEvents = listOf(event1),
+            retryCount = 2,
+            appProperties = SnowplowAppProperties("app-test", "http://localhost:1080", "test"),
+            onFailure = failureCallback,
+            onSuccess = successCallback
+        )
+
+        verify(timeout = 500, exactly = 1) { successCallback(1) }
+        verify(timeout = 500, exactly = 0) { failureCallback(any(), any()) }
+    }
+
+    @Test
+    fun `should call failure callback after failures with retry attempts`() {
+        val event1: Event = Fixtures.event(userId = "user-1")
+        val event2: Event = Fixtures.event(userId = "user-2")
+
+        retryFailedEvent(
+            failedEvents = listOf(event1, event2),
+            retryCount = 2,
+            appProperties = SnowplowAppProperties("app-test", "http://localhost:1081", "test"),
+            onFailure = failureCallback,
+            onSuccess = successCallback
+        )
+
+        verify(timeout = 400, exactly = 0) { failureCallback(any(), any()) }
+        verify(timeout = 1200, exactly = 1) { failureCallback(0, listOf(event1)) }
+        verify(timeout = 1200, exactly = 1) { failureCallback(0, listOf(event2)) }
     }
 }

--- a/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherTest.kt
+++ b/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherTest.kt
@@ -1,10 +1,6 @@
 package snowplowjavatrackertracker
 
-import com.snowplowanalytics.snowplow.tracker.Subject
 import com.snowplowanalytics.snowplow.tracker.Tracker
-import com.snowplowanalytics.snowplow.tracker.events.Unstructured
-import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson
-import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
@@ -17,11 +13,7 @@ class SnowplowDispatcherTest {
     fun `should call track`() {
         val tracker: Tracker = mockk(relaxed = true)
         val dispatcher = SnowplowDispatcher(tracker)
-        val json = SelfDescribingJson("schema", TrackerPayload().apply { addMap(mapOf("key" to "value")) })
-        val event = Unstructured.builder()
-            .eventData(json)
-            .subject(Subject.SubjectBuilder().userId("my-id-1").build())
-            .build()
+        val event = Fixtures.event()
 
         dispatcher.send(event)
 

--- a/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherTest.kt
+++ b/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle
 
 @TestInstance(Lifecycle.PER_CLASS)
 class SnowplowDispatcherTest {
+
     @Test
     fun `should call track`() {
         val tracker: Tracker = mockk(relaxed = true)

--- a/src/test/kotlin/snowplowjavatrackertracker/mockserver/MockServer.kt
+++ b/src/test/kotlin/snowplowjavatrackertracker/mockserver/MockServer.kt
@@ -1,6 +1,6 @@
 package snowplowjavatrackertracker.mockserver
 
-import org.mockserver.client.server.MockServerClient
+import org.mockserver.client.MockServerClient
 import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse.response
 


### PR DESCRIPTION
## What : 
- Adds a retry capability for failed events which can be used by clients in failure callbacks
- dependency upgrade and unused dependency removal