### PR TITLE
[PLATFORM-95] Change to count down latch to maintain counter

### DIFF
--- a/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherIntegrationTest.kt
+++ b/src/test/kotlin/snowplowjavatrackertracker/SnowplowDispatcherIntegrationTest.kt
@@ -53,14 +53,15 @@ class SnowplowDispatcherIntegrationTest {
             "my-name",
             "app",
             "http://localhost:1080",
-            1, 1
+            1,
+            1
         )
 
         dispatcher.send(event)
     }
 
     @Test
-    fun `should call failure callback after failure with retry attempts`(){
+    fun `should call failure callback after failure with retry attempts`() {
         val dispatcher = snowplowDispatcher(
             appId = "my-app-id",
             nameSpace = "app-namespace",
@@ -76,7 +77,7 @@ class SnowplowDispatcherIntegrationTest {
         dispatcher.send(event2)
 
         verify(timeout = 400, exactly = 0) { failureCallback(any(), any()) }
-        verify(timeout = 1200, exactly = 1) { failureCallback(0, listOf(event1)) }
-        verify(timeout = 1200, exactly = 1) { failureCallback(0, listOf(event2)) }
+        verify(timeout = 4000, exactly = 1) { failureCallback(0, listOf(event1)) }
+        verify(timeout = 4000, exactly = 1) { failureCallback(0, listOf(event2)) }
     }
 }


### PR DESCRIPTION
## What : 
- Change to countdown latch to maintain retrial counts

### Tested with `audio-event-handler` 
Following logs to confirm on retrial attempts
```
2021-02-20 22:47:44.964  INFO 61615 --- [pool-2-thread-1] s.RetryFailedEvents                      : Retrying to send event : com.snowplowanalytics.snowplow.tracker.events.Unstructured@441f207e, attemptCount: 1
2021-02-20 22:47:45.309 ERROR 61615 --- [pool-3-thread-1] c.s.s.tracker.emitter.BatchEmitter       : BatchEmitter failed to send 1 events: code: 404
2021-02-20 22:47:45.311  INFO 61615 --- [pool-3-thread-1] s.RetryFailedEvents                      : retryFailure: java.util.stream.ReferencePipeline$3@223ccb17
2021-02-20 22:47:49.835  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying after 4484.0 milliseconds
2021-02-20 22:47:49.836  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying to send event : com.snowplowanalytics.snowplow.tracker.events.Unstructured@441f207e, attemptCount: 2
2021-02-20 22:47:50.055 ERROR 61615 --- [pool-3-thread-1] c.s.s.tracker.emitter.BatchEmitter       : BatchEmitter failed to send 1 events: code: 404
2021-02-20 22:47:50.056  INFO 61615 --- [pool-3-thread-1] s.RetryFailedEvents                      : retryFailure: java.util.stream.ReferencePipeline$3@4982047f
2021-02-20 22:47:58.544  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying after 8484.0 milliseconds
2021-02-20 22:47:58.544  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying to send event : com.snowplowanalytics.snowplow.tracker.events.Unstructured@441f207e, attemptCount: 3
2021-02-20 22:47:58.777 ERROR 61615 --- [pool-3-thread-2] c.s.s.tracker.emitter.BatchEmitter       : BatchEmitter failed to send 1 events: code: 404
2021-02-20 22:47:58.778  INFO 61615 --- [pool-3-thread-2] s.RetryFailedEvents                      : retryFailure: java.util.stream.ReferencePipeline$3@6867e7dc
2021-02-20 22:48:15.269  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying after 16484.0 milliseconds
2021-02-20 22:48:15.270  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying to send event : com.snowplowanalytics.snowplow.tracker.events.Unstructured@441f207e, attemptCount: 4
2021-02-20 22:48:15.489 ERROR 61615 --- [pool-3-thread-1] c.s.s.tracker.emitter.BatchEmitter       : BatchEmitter failed to send 1 events: code: 404
2021-02-20 22:48:15.489  INFO 61615 --- [pool-3-thread-1] s.RetryFailedEvents                      : retryFailure: java.util.stream.ReferencePipeline$3@5670c3b0
2021-02-20 22:48:47.976  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying after 32484.0 milliseconds
2021-02-20 22:48:47.976  INFO 61615 --- [atcher-worker-1] s.RetryFailedEvents                      : Retrying to send event : com.snowplowanalytics.snowplow.tracker.events.Unstructured@441f207e, attemptCount: 5
2021-02-20 22:48:48.291 ERROR 61615 --- [pool-3-thread-3] c.s.s.tracker.emitter.BatchEmitter       : BatchEmitter failed to send 1 events: code: 404
2021-02-20 22:48:48.291  INFO 61615 --- [pool-3-thread-3] s.RetryFailedEvents                      : retryFailure: java.util.stream.ReferencePipeline$3@24f904be
```